### PR TITLE
Make the web app relocatable

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,14 +2,14 @@
     "name": "Forest VR",
     "icons": [
         {
-            "src": "http://forestvr.onepopcorn.com/assets/images/icons/android-chrome-144x144.png",
+            "src": "./assets/images/icons/android-chrome-144x144.png",
             "sizes": "144x144",
             "type": "image/png"
         }
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "start_url": "http://forestvr.onepopcorn.com",
+    "start_url": "./index.html",
     "display": "standalone",
     "orientation": "landscape"
 }


### PR DESCRIPTION
Rather than hard-coding the hostname and directory for the icon and start_url,
use a relative URL so that we can host the app in different subdirectories and
servers without having to customize the web app manifest each time.

Signed-off-by: Dan Scott <dan@coffeecode.net>